### PR TITLE
fix: change makefile listen to correctly use cly.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ setup:
 
 listen:
 	@echo "🎹 Starting interactive MIDI listener..."
-	python3 midi_listener.py
+	python3 cli.py midi-listen
 
 install:
 	@echo "📦 Installing to $(INSTALL_DIR)..."

--- a/README.md
+++ b/README.md
@@ -333,3 +333,10 @@ Install dependencies with:
 ```bash
 pip install -r requirements.txt
 ```
+
+## 📋 TODO
+
+- 🎚️ Adding a GUI or system tray app
+- 🐍 Publishing to PyPI
+- 🧪 Adding tests / GitHub Actions
+- 📦 Turning this into a plug-and-play installer

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Built to run persistently on Linux using a `distrobox` container or systemd user
 - [🚀 Background Service Setup (Optional)](#-background-service-setup-optional-recommended)
 - [📂 Project Structure](#-project-structure)
 - [✅ Requirements](#-requirements)
+- [📋 TODO](#-todo)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ pip install -r requirements.txt
 ## 📋 TODO
 
 - 🎚️ Adding a GUI or system tray app
+- ✈️ Adding application launcher commands
+- 🔄 Adding OBS scene switching commands
 - 🐍 Publishing to PyPI
 - 🧪 Adding tests / GitHub Actions
 - 📦 Turning this into a plug-and-play installer


### PR DESCRIPTION
Previously the MakeFile listen command was pointing to midi_listener.py which used to be in root. This was renamed and moved to /utils.
We should just call this with the cli command for consistency