### PR TITLE
fix: change makefile listen to correctly use cly.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ setup:
 
 listen:
 	@echo "🎹 Starting interactive MIDI listener..."
-	python3 midi_listener.py
+	python3 cli.py midi-listen
 
 install:
 	@echo "📦 Installing to $(INSTALL_DIR)..."


### PR DESCRIPTION
Previously the MakeFile listen command was pointing to midi_listener.py which used to be in root. This was renamed and moved to /utils.
We should just call this with the cli command for consistency